### PR TITLE
Add manifests for skovati.dev svc and traefik letsencrypt

### DIFF
--- a/skovati.dev/cloudflare-api-secret.yaml
+++ b/skovati.dev/cloudflare-api-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cloudflare-api-skovati
+  namespace: kube-system
+data:
+  dns-token: YOUR_API_TOKEN_HERE # (base64 encoded)

--- a/skovati.dev/skovati-deploy.yaml
+++ b/skovati.dev/skovati-deploy.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skovati-deploy
+  labels:
+    app: skovati
+  namespace: skovati-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: skovati-dev
+  template:
+    metadata:
+      labels:
+        app: skovati-dev
+    spec:
+      containers:
+      - name: skovati-dev
+        image: ghcr.io/skovati/website:latest
+        ports:
+        - containerPort: 80

--- a/skovati.dev/skovati-ingress.yaml
+++ b/skovati.dev/skovati-ingress.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-http
+  namespace: skovati-dev
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: skovati-ingress
+  namespace: skovati-dev
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls.certresolver: le-skovati
+spec:
+  rules:
+    - host: skovati.dev
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: skovati-svc
+                port:
+                  number: 8080
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: skovati-ingress-http
+  namespace: skovati-dev
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.middlewares: skovati-dev-redirect-http@kubernetescrd
+spec:
+  rules:
+    - host: skovati.dev
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: skovati-svc
+                port:
+                  number: 8080

--- a/skovati.dev/skovati-svc.yaml
+++ b/skovati.dev/skovati-svc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: skovati-svc
+  namespace: skovati-dev
+spec:
+  ports:
+  - name: skovati-dev-port
+    port: 8080
+    targetPort: 80
+  selector:
+    app: skovati-dev

--- a/traefik/traefik-update.yaml
+++ b/traefik/traefik-update.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    additionalArguments:
+      - "--certificatesresolvers.le-skovati.acme.email=YOUR_EMAIL@example.com"
+      - "--certificatesresolvers.le-skovati.acme.storage=/data/acme.json"
+      - "--certificatesresolvers.le-skovati.acme.caserver=https://acme-v02.api.letsencrypt.org/directory"
+      - "--certificatesResolvers.le-skovati.acme.dnschallenge=true"
+      - "--certificatesResolvers.le-skovati.acme.dnschallenge.provider=cloudflare"
+      - "--api.insecure=true"
+      - "--accesslog=true"
+      - "--log.level=INFO"
+    env:
+      - name: CF_DNS_API_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: cloudflare-api-skovati
+            key: dns-token


### PR DESCRIPTION
Adds initial manifests for skovati.dev hosting. Can be used as a starting point for other static websites we want to host.